### PR TITLE
Add autocomplete=off to the input

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 				<div class="col-xs-8 col-xs-offset-2">
 					<form id="notes-form">
 						<div class="form-group">
-							<input id='note-text' class="form-control" type="text" placeholder="Type note here..." />
+							<input id='note-text' class="form-control" type="text" placeholder="Type note here..." autocomplete="off" />
 						</div>
 						<div class="pull-right">
 							<button type="submit" class="btn btn-primary">Take Note</button>


### PR DESCRIPTION
## Issue
- When typing notes, I get distracted by the "autocomplete" functionality of the input
![Screen Shot 2021-11-12 at 11 32 20](https://user-images.githubusercontent.com/108884/141501534-a5feee40-99dc-4623-b2f4-3828afc6bd3d.png)

## Solution
- Add the `autocomplete='off'` attribute to the input.
- I'm not sure I ever want to repeat something in my timed notes... but feel free to close / ignore if you think that it's a useful feature
